### PR TITLE
Removing the .flags file

### DIFF
--- a/.flags
+++ b/.flags
@@ -1,17 +1,5 @@
 {
-  "south_light": "\u26ab",
-  "east_light": "\ud83d\udfe2",
-  "east_turn": 1673289619.902551,
-  "north_light": "\ud83d\udfe2",
-  "west_light": "\ud83d\udd34",
-  "west_time": 1673289760.972291,
-  "cwd": "/world/city/Ix/dluman/traffic-circle",
-  "north_west_light": "\ud83d\udfe2",
-  "north_west_crosswalk": "\u2714\ufe0f",
-  "south_west_light": "\ud83d\udd34",
-  "south_west_crosswalk": "\u2714\ufe0f",
-  "north_north_east_light": "\ud83d\udfe2",
-  "east_north_east_light": "\ud83d\udd34",
-  "north_north_east_traffic": "\u274c",
-  "east_north_east_traffic": "\u274c"
+  "cwd": "/world/city/Ix/dluman/traffic-circle-solution",
+  "west_light": "\ud83d\udfe2",
+  "west_time": 1673295272.879921
 }

--- a/west/Stoplight.py
+++ b/west/Stoplight.py
@@ -18,7 +18,7 @@ class Stoplight(FixtureSpec):
 
     def __time_now(self) -> str:
         now = datetime.now().timestamp()
-       return now
+        return now
 
     def __timing(self) -> bool:
         now = float(self.__time_now())


### PR DESCRIPTION
Need to reconcile the changes here, but this should fix a small typographical issue in `west/Stoplight.py` and hopefully update the `.gitignore` to _exclude_ the `.flags` file.